### PR TITLE
Provide package versions that are compatible with PEP440

### DIFF
--- a/dsautils/version.py
+++ b/dsautils/version.py
@@ -113,7 +113,10 @@ def get_git_version(abbrev=7):
         write_release_version(version)
 
     # Finally, return the current version.
-
+    if version[0] == 'v':
+        version = version[1:]
+    version = version.replace("-", "+", 1)
+    
     return version
 
 


### PR DESCRIPTION
The use of pip to install packages with versions that are not compatible with PEP440 is deprecated.  I made a simple change to remove the leading "v" if it's present and to use a "+" to separate the semantic version tag from the git hash and other info, and replaced "-" with ".".

As an example, for a git describe of "v3.5.6-60-gd2a7c67" the version used to be "v3.5.6-60-gd2a7c67-dirty" and with these changes would be "3.5.6+60.gd2a7c67.dirty".

Thoughts on this convention change @rh-codebase @caseyjlaw ?